### PR TITLE
fix: add missing space

### DIFF
--- a/attendee/index.html
+++ b/attendee/index.html
@@ -28,7 +28,7 @@
     <h2>How It Works</h2>
     <div class="step-container">
       <div class="step-content">
-        <p>Build a 2D platformer game in 1-2 hours! Learn how to useGodot, GitHub, and Itch.io. Then you'll be ready for Daydream!</p>
+        <p>Build a 2D platformer game in 1-2 hours! Learn how to use Godot, GitHub, and Itch.io. Then you'll be ready for Daydream!</p>
 
         <p>Use the resources below to create and publish your game.
       </div>


### PR DESCRIPTION
Adds a missing space to "Learn how to use Godot, GitHub, and Itch.io." section